### PR TITLE
Fix issue where wrong request path was being matched.

### DIFF
--- a/server/index-html.js
+++ b/server/index-html.js
@@ -55,7 +55,7 @@ app.use("*", (req, res, next) => {
 
   sendLayoutHTTPResponse({
     serverLayout,
-    urlPath: req.path,
+    urlPath: req.originalUrl,
     res,
     renderFragment,
     async renderApplication({ appName, propsPromise }) {


### PR DESCRIPTION
`req.originalUrl` is `/pokemons` when `req.path` is `/`. We want it to be the original url